### PR TITLE
DELIA-67068: DCM Agent is using difw script

### DIFF
--- a/dcm.c
+++ b/dcm.c
@@ -56,7 +56,7 @@ static VOID dcmRunJobs(const INT8* profileName, VOID *pHandle)
         return;
     }
     if(dcmSettingsGetMMFlag()) {
-        DCMError("Maintenance manager enable so cron job schedule not allowed\n");
+        DCMInfo("Maintenance manager enabled device - Cron job schedules for maintenance activities are disabled\n");
         return;
     }
 


### PR DESCRIPTION
Reason for change: * replace difw script to swupdate_utils.sh script, Which is
                     called difw script inside. Make sure if maintenance manager is
                     enable then dcm should not schedule difw.
Test Procedure: Build should pass and L1 Unit Test all Test case should pass Risks: Low
Priority: P1