### PR TITLE
RDKEMW-3584: Load Default config during the start of dcm-agent

### DIFF
--- a/dcm.c
+++ b/dcm.c
@@ -303,13 +303,13 @@ int main(int argc, char* argv[])
 
     DCMDebug("Initializing DCM Component Done\n");
 
-    #ifdef DCM_DEFAULT_BOOTCONFIG
-    DCMInfo("Loading the Default config from : %s\n",DCM_DEFAULT_BOOTCONFIG);
-    ret = dcmSettingDefaultBoot(DCM_DEFAULT_BOOTCONFIG);
+    //#ifdef DCM_DEFAULT_BOOTCONFIG // make this default as this is inline with legacy implementation
+    DCMInfo("Loading the Default config\n");
+    ret = dcmSettingDefaultBoot();
     if(ret != DCM_SUCCESS) {
         DCMError("Failed to load default config file\n");
     }
-    #endif
+    //#endif
 
     while(1) {
         if(count > 10) {

--- a/dcm.c
+++ b/dcm.c
@@ -303,6 +303,14 @@ int main(int argc, char* argv[])
 
     DCMDebug("Initializing DCM Component Done\n");
 
+    #ifdef DCM_DEFAULT_BOOTCONFIG
+    DCMInfo("Loading the Default config from : %s\n",DCM_DEFAULT_BOOTCONFIG);
+    ret = dcmSettingDefaultBoot(DCM_DEFAULT_BOOTCONFIG);
+    if(ret != DCM_SUCCESS) {
+        DCMError("Failed to load default config file\n");
+    }
+    #endif
+
     while(1) {
         if(count > 10) {
             DCMInfo("Waiting for Telemetry to up and running to Subscribe the events\n");

--- a/dcm_parseconf.c
+++ b/dcm_parseconf.c
@@ -694,3 +694,25 @@ VOID dcmSettingsUnInit(VOID *pdcmSetHandle)
         DCMError("Input Handle is NULL\n");
     }
 }
+
+#ifdef DCM_DEFAULT_BOOTCONFIG
+/** @brief This Function Parses the default config file post bootup.
+ *
+ *  @param[]  None
+ *
+ *  @return  Returns the status of the operation.
+ *  @retval  Returns DCM_SUCCESS on success, DCM_FAILURE otherwise.
+ */
+
+ INT32 dcmSettingDefaultBoot(INT8 *defaultConfig)
+ {
+    if (defaultConfig == NULL) {
+        DCMError("Input defaultConfig is NULL\n");
+        return DCM_FAILURE;
+    }
+    else {
+        return dcmSettingStoreTempConf(defaultConfig, DCM_TMP_CONF, DCM_OPT_CONF);
+    }
+ }
+ #endif //DCM_DEFAULT_BOOTCONFIG
+ 

--- a/dcm_parseconf.c
+++ b/dcm_parseconf.c
@@ -695,7 +695,6 @@ VOID dcmSettingsUnInit(VOID *pdcmSetHandle)
     }
 }
 
-#ifdef DCM_DEFAULT_BOOTCONFIG
 /** @brief This Function Parses the default config file post bootup.
  *
  *  @param[]  None
@@ -704,15 +703,23 @@ VOID dcmSettingsUnInit(VOID *pdcmSetHandle)
  *  @retval  Returns DCM_SUCCESS on success, DCM_FAILURE otherwise.
  */
 
- INT32 dcmSettingDefaultBoot(INT8 *defaultConfig)
+ INT32 dcmSettingDefaultBoot()
  {
-    if (defaultConfig == NULL) {
-        DCMError("Input defaultConfig is NULL\n");
+    char* persistentPath = dcmUtilsGetFileEntry(INCLUDE_PROP_FILE,PERSISTENT_ENTRY);
+    if(persistentPath == NULL)
+    {
+        persistentPath = strdup(DEFAULT_PERSISTENT_PATH);
+        DCMError("Error in fetching %s from %s, using default path:%s\n",PERSISTENT_ENTRY,INCLUDE_PROP_FILE,persistentPath);
+    }
+    char defaultConfig[512];
+    snprintf(defaultConfig,sizeof(defaultConfig),"%s%s",persistentPath,DCM_RESPONSE_PATH);
+    free(persistentPath);
+    DCMInfo("Fetching the Default Boot config from %s\n",defaultConfig);
+    if(dcmUtilsFilePresentCheck(defaultConfig)!= DCM_SUCCESS)
+    {
+        DCMError("DCMResponse File is not present, skip default boot config\n");
         return DCM_FAILURE;
     }
-    else {
-        return dcmSettingStoreTempConf(defaultConfig, DCM_TMP_CONF, DCM_OPT_CONF);
-    }
+    return dcmSettingStoreTempConf(defaultConfig, DCM_TMP_CONF, DCM_OPT_CONF);
  }
- #endif //DCM_DEFAULT_BOOTCONFIG
  

--- a/dcm_parseconf.h
+++ b/dcm_parseconf.h
@@ -63,9 +63,6 @@ INT8*  dcmSettingsGetUploadProtocol(VOID *pdcmSetHandle);
 INT8*  dcmSettingsGetUploadURL(VOID *pdcmSetHandle);
 INT8*  dcmSettingsGetRDKPath(VOID *pdcmSetHandle);
 INT32  dcmSettingsGetMMFlag();
-
-#ifdef DCM_DEFAULT_BOOTCONFIG
-INT32 dcmSettingDefaultBoot(INT8 *defaultConfig);
-#endif //DCM_DEFAULT_BOOTCONFIG
+INT32 dcmSettingDefaultBoot();
 
 #endif //_DCM_PARSECONF_H_

--- a/dcm_parseconf.h
+++ b/dcm_parseconf.h
@@ -64,4 +64,8 @@ INT8*  dcmSettingsGetUploadURL(VOID *pdcmSetHandle);
 INT8*  dcmSettingsGetRDKPath(VOID *pdcmSetHandle);
 INT32  dcmSettingsGetMMFlag();
 
+#ifdef DCM_DEFAULT_BOOTCONFIG
+INT32 dcmSettingDefaultBoot(INT8 *defaultConfig);
+#endif //DCM_DEFAULT_BOOTCONFIG
+
 #endif //_DCM_PARSECONF_H_

--- a/dcm_utils.c
+++ b/dcm_utils.c
@@ -201,3 +201,55 @@ INT32 dcmIARMEvntSend(INT32 status)
     INT32 ret = DCM_SUCCESS;
     return ret;
 }
+
+
+/**
+ * @brief Fetch the value of a given entry from a file (simple key=value format).
+ *
+ * This function searches for a line in the form "key=value" within the specified file and returns
+ * a heap-allocated string containing the associated value for the given key.
+ *
+ * @param[in] fileName      Path to the file to search (must not be NULL).
+ * @param[in] searchEntry   Entry key to search for (must not be NULL).
+ *
+ * @return  Pointer to a heap-allocated string containing the entry value (must be freed by the caller),
+ *          or NULL if the entry is not found or if an error occurs.
+ *
+ * @note This function expects:
+ *       - The file contains lines in the format "key=value" (no comments).
+ *       - There is no whitespace before or after the '=' character.
+ *       - The search is case-sensitive.
+ */
+
+INT8* dcmUtilsGetFileEntry(const INT8* fileName, const INT8* searchEntry)
+{
+    if(fileName == NULL || searchEntry == NULL)
+    {
+        return NULL;
+    }
+    FILE *fp = NULL;
+    char* entryValue = NULL;
+
+    fp = fopen(fileName, "r");
+    if(NULL != fp)
+    {
+        char line[512];
+        size_t entryLen = strlen(searchEntry);
+        while (fgets(line, sizeof(line), fp))
+        {
+            if (line[entryLen] == '=' && strncmp(line, searchEntry, entryLen) == 0 )
+            {
+                char *value = line + entryLen + 1;
+                char *checkNewline = strpbrk(value, "\r\n"); // just a saftey check
+                if (checkNewline)
+                {
+                    *checkNewline = '\0';
+                }
+                entryValue = strdup(value);
+                break;
+            }
+        }
+        fclose(fp);
+    }
+    return entryValue;
+}

--- a/dcm_utils.h
+++ b/dcm_utils.h
@@ -40,6 +40,9 @@
 #define INCLUDE_PROP_FILE            "/etc/include.properties"
 #define DCM_TMP_CONF                 "/tmp/DCMSettings.conf"
 #define DCM_OPT_CONF                 "/opt/.DCMSettings.conf"
+#define DCM_RESPONSE_PATH            "/.t2persistentfolder/DCMresponse.txt"
+#define PERSISTENT_ENTRY             "PERSISTENT_PATH"
+#define DEFAULT_PERSISTENT_PATH      "/opt"
 
 #ifndef DCM_LOG_TFTP // please define your log upload url
 #define DCM_LOG_TFTP                 "Fallbacklogupload"
@@ -111,6 +114,7 @@ VOID  dcmUtilsCopyCommandOutput (INT8 *cmd, INT8 *out, INT32 len);
 INT32 dcmUtilsCheckDaemonStatus();
 VOID  dcmUtilsRemovePIDfile();
 INT32 dcmUtilsFilePresentCheck(const INT8 *file_name);
+INT8* dcmUtilsGetFileEntry(const INT8* fileName, const INT8* searchEntry);
 
 void DCMLOGInit();
 


### PR DESCRIPTION
Reason for change: dcm-agent should load the default config from the persistent path
Test Procedure: check Dcmsettings.conf is created at the earliest if we have DCMresponse.txt
Risks: Low