### PR TITLE
RDKEMW-17026 : Remove OEM/SOC references from the module

### DIFF
--- a/usbLogUpload/README.md
+++ b/usbLogUpload/README.md
@@ -89,14 +89,14 @@ The module reads configuration from:
 
 ### Environment Variables
 
-- `DEVICE_NAME`: Device type identifier (must be "PLATCO")
+- `DEVICE_NAME`: Device type identifier (must be "TV")
 - `RDK_PATH`: RDK library path (default: `/lib/rdk`)
 - `LOG_PATH`: System log directory path
 - `SYSLOG_NG_ENABLED`: Syslog-ng service status
 
 ## Features
 
-- **Device Validation**: Supports PLATCO devices only
+- **Device Validation**: Supports TV devices only
 - **Log Archival**: Creates compressed `.tgz` archives
 - **Naming Convention**: `<MAC>_Logs_<timestamp>.tgz`
 - **Service Management**: Reloads syslog-ng after log transfer

--- a/usbLogUpload/docs/shared-functions-analysis.md
+++ b/usbLogUpload/docs/shared-functions-analysis.md
@@ -47,7 +47,7 @@
 
 3. **USB-Specific Implementation:**
    - USB mount point validation
-   - Device compatibility checks (PLATCO-only requirement)
+   - Device compatibility checks (TV-only requirement)
    - syslog-ng service restart logic
 
 ## Implementation Benefits:

--- a/usbLogUpload/docs/usb-log-upload-flowcharts.md
+++ b/usbLogUpload/docs/usb-log-upload-flowcharts.md
@@ -20,7 +20,7 @@ flowchart TD
     ConfigOK -->|No| Exit6[Exit Code 6: Config Error]
     
     ConfigOK -->|Yes| DeviceCheck[Check Device Compatibility]
-    DeviceCheck --> DeviceOK{Device == PLATCO?}
+    DeviceCheck --> DeviceOK{Device == TV?}
     DeviceOK -->|No| Exit4_Device[Exit Code 4: Unsupported Device]
     
     DeviceOK -->|Yes| USBCheck[Validate USB Mount Point]
@@ -74,7 +74,7 @@ Config OK? ──NO──→ EXIT(6)
   ↓ YES
 Check Device Type
   ↓
-PLATCO Device? ──NO──→ EXIT(4)
+TV Device? ──NO──→ EXIT(4)
   ↓ YES  
 Validate USB Mount
   ↓
@@ -114,7 +114,7 @@ EXIT(0)
 ```mermaid
 flowchart TD
     ValidateStart([Validation Start]) --> CheckDevice[Check Device Name]
-    CheckDevice --> DeviceMatch{Device == PLATCO?}
+    CheckDevice --> DeviceMatch{Device == TV?}
     DeviceMatch -->|No| DeviceFail[Return Device Error]
     DeviceMatch -->|Yes| CheckUSB[Validate USB Mount Point]
     

--- a/usbLogUpload/docs/usb-log-upload-requirements.md
+++ b/usbLogUpload/docs/usb-log-upload-requirements.md
@@ -7,7 +7,7 @@ This document outlines the functional requirements for migrating the `usbLogUplo
 
 ### Core Functionality
 1. **USB Log Transfer**: Transfer system logs from embedded device to external USB storage
-2. **Device Validation**: Verify device compatibility (currently PLATCO devices only)
+2. **Device Validation**: Verify device compatibility (currently TV devices only)
 3. **Log Archival**: Create compressed archive (.tgz) of log files with proper naming convention
 4. **Log Management**: Move logs from system location to USB, reload logging service
 

--- a/usbLogUpload/include/usb_log_validation.h
+++ b/usbLogUpload/include/usb_log_validation.h
@@ -54,7 +54,7 @@ int validate_input_parameters(int argc, char *argv[]);
  * @brief Validate device compatibility
  * 
  * Checks if the current device supports USB log upload functionality.
- * Currently only PLATCO devices are supported.
+ * Currently only TV devices are supported.
  * 
  * @return int 0 if compatible, negative error code otherwise
  */

--- a/usbLogUpload/src/usb_log_validation.c
+++ b/usbLogUpload/src/usb_log_validation.c
@@ -107,7 +107,7 @@ int validate_device_compatibility(void)
         return 4;
     }
     
-    /* Check if device is PLATCO (only supported device) */
+    /* Check if device is TV (only supported device) */
     if (strcmp(device_name, "TV") != 0) {
         RDK_LOG(RDK_LOG_ERROR, LOG_USB_UPLOAD, 
                 "[%s:%d] ERROR! USB Log download not available on this device.\n", 


### PR DESCRIPTION
Reason for change: Remove OEM/SOC references from the module
Test Procedure: NA
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)