### PR TITLE
 [support/8.5] RDKEMW-17579 : Log-backup generated is named with local timestamp instead of UTC timestamp 

### DIFF
--- a/uploadstblogs/src/archive_manager.c
+++ b/uploadstblogs/src/archive_manager.c
@@ -415,20 +415,18 @@ bool generate_archive_name(char* buffer, size_t buffer_size,
     }
 
     time_t now = time(NULL);
-
-    struct tm tm_utc;
-    if (gmtime_r(&now, &tm_utc) == NULL) {
-        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] Failed to get UTC time\n", __FUNCTION__, __LINE__);
+    struct tm* tm_info = localtime(&now);
+    
+    if (!tm_info) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+                "[%s:%d] Failed to get local time\n", __FUNCTION__, __LINE__);
         return false;
     }
 
     char timestamp[32];
-    // Format UTC timestamp as MM-DD-YY-HH-MMAM/PM.
-    if (strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p", &tm_utc) == 0) {
-        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
-                "[%s:%d] Failed to format timestamp\n", __FUNCTION__, __LINE__);
-        return false;
-    }
+    // Format: MM-DD-YY-HH-MMAM/PM (matches script: date "+%m-%d-%y-%I-%M%p")
+    strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p", tm_info);
+    
     // Remove colons from MAC address for filename (A8:4A:63 -> A84A63)
     char mac_clean[32];
     const char* src = mac_address;
@@ -702,7 +700,7 @@ static int create_archive_with_options(RuntimeContext* ctx, SessionState* sessio
     RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB,
             "[%s:%d] Creating archive with MAC='%s', prefix='%s'\n",
             __FUNCTION__, __LINE__, 
-            (ctx->mac_address[0] != '\0') ? ctx->mac_address : "(NULL)", 
+            ctx->mac_address ? ctx->mac_address : "(NULL)", 
             prefix);
     
     char archive_filename[MAX_FILENAME_LENGTH];
@@ -738,36 +736,10 @@ static int create_archive_with_options(RuntimeContext* ctx, SessionState* sessio
     // Write two 512-byte blocks of zeros (TAR EOF marker)
     char eof_blocks[TAR_BLOCK_SIZE * 2];
     memset(eof_blocks, 0, sizeof(eof_blocks));
-    if (gzwrite(gz, eof_blocks, sizeof(eof_blocks)) != sizeof(eof_blocks)) {
-        int zerr = Z_OK;
-        const char* zmsg = gzerror(gz, &zerr);
-        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
-                "[%s:%d] gzwrite failed to write EOF blocks (zerr=%d, msg=%s)\n",
-                __FUNCTION__, __LINE__, zerr, zmsg ? zmsg : "(null)");
-        ret = -1;
-    }
+    gzwrite(gz, eof_blocks, sizeof(eof_blocks));
     
     // Close gzip file
-    int gzclose_ret = gzclose(gz);
-    if (gzclose_ret != Z_OK) {
-        const char* zmsg = zError(gzclose_ret);
-        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
-            "[%s:%d] gzclose failed (zret=%d, msg=%s)\n",
-            __FUNCTION__, __LINE__, gzclose_ret, zmsg ? zmsg : "(null)");
-        ret = -1;
-    }
-
-    if (ret != 0 && file_exists(archive_path)) {
-        RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB,
-                "[%s:%d] Removing incomplete archive: %s\n",
-                __FUNCTION__, __LINE__, archive_path);
-        errno = 0;
-        if (!remove_file(archive_path)) {
-            RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
-                    "[%s:%d] Failed to remove incomplete archive: %s (errno=%d, %s)\n",
-                    __FUNCTION__, __LINE__, archive_path, errno, strerror(errno));
-        }
-    }
+    gzclose(gz);
 
     if (ret == 0 && file_exists(archive_path)) {
         long size = get_archive_size(archive_path);

--- a/uploadstblogs/src/archive_manager.c
+++ b/uploadstblogs/src/archive_manager.c
@@ -415,18 +415,20 @@ bool generate_archive_name(char* buffer, size_t buffer_size,
     }
 
     time_t now = time(NULL);
-    struct tm* tm_info = localtime(&now);
-    
-    if (!tm_info) {
-        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
-                "[%s:%d] Failed to get local time\n", __FUNCTION__, __LINE__);
+
+    struct tm tm_utc;
+    if (gmtime_r(&now, &tm_utc) == NULL) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] Failed to get UTC time\n", __FUNCTION__, __LINE__);
         return false;
     }
 
     char timestamp[32];
-    // Format: MM-DD-YY-HH-MMAM/PM (matches script: date "+%m-%d-%y-%I-%M%p")
-    strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p", tm_info);
-    
+    // Format UTC timestamp as MM-DD-YY-HH-MMAM/PM.
+    if (strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p", &tm_utc) == 0) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+                "[%s:%d] Failed to format timestamp\n", __FUNCTION__, __LINE__);
+        return false;
+    }
     // Remove colons from MAC address for filename (A8:4A:63 -> A84A63)
     char mac_clean[32];
     const char* src = mac_address;
@@ -700,7 +702,7 @@ static int create_archive_with_options(RuntimeContext* ctx, SessionState* sessio
     RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB,
             "[%s:%d] Creating archive with MAC='%s', prefix='%s'\n",
             __FUNCTION__, __LINE__, 
-            ctx->mac_address ? ctx->mac_address : "(NULL)", 
+            (ctx->mac_address[0] != '\0') ? ctx->mac_address : "(NULL)", 
             prefix);
     
     char archive_filename[MAX_FILENAME_LENGTH];
@@ -736,10 +738,36 @@ static int create_archive_with_options(RuntimeContext* ctx, SessionState* sessio
     // Write two 512-byte blocks of zeros (TAR EOF marker)
     char eof_blocks[TAR_BLOCK_SIZE * 2];
     memset(eof_blocks, 0, sizeof(eof_blocks));
-    gzwrite(gz, eof_blocks, sizeof(eof_blocks));
+    if (gzwrite(gz, eof_blocks, sizeof(eof_blocks)) != sizeof(eof_blocks)) {
+        int zerr = Z_OK;
+        const char* zmsg = gzerror(gz, &zerr);
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+                "[%s:%d] gzwrite failed to write EOF blocks (zerr=%d, msg=%s)\n",
+                __FUNCTION__, __LINE__, zerr, zmsg ? zmsg : "(null)");
+        ret = -1;
+    }
     
     // Close gzip file
-    gzclose(gz);
+    int gzclose_ret = gzclose(gz);
+    if (gzclose_ret != Z_OK) {
+        const char* zmsg = zError(gzclose_ret);
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+            "[%s:%d] gzclose failed (zret=%d, msg=%s)\n",
+            __FUNCTION__, __LINE__, gzclose_ret, zmsg ? zmsg : "(null)");
+        ret = -1;
+    }
+
+    if (ret != 0 && file_exists(archive_path)) {
+        RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB,
+                "[%s:%d] Removing incomplete archive: %s\n",
+                __FUNCTION__, __LINE__, archive_path);
+        errno = 0;
+        if (!remove_file(archive_path)) {
+            RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+                    "[%s:%d] Failed to remove incomplete archive: %s (errno=%d, %s)\n",
+                    __FUNCTION__, __LINE__, archive_path, errno, strerror(errno));
+        }
+    }
 
     if (ret == 0 && file_exists(archive_path)) {
         long size = get_archive_size(archive_path);

--- a/uploadstblogs/src/archive_manager.c
+++ b/uploadstblogs/src/archive_manager.c
@@ -449,6 +449,7 @@ bool generate_archive_name(char* buffer, size_t buffer_size,
             __FUNCTION__, __LINE__, buffer, mac_address, prefix);
     
     return true;
+
 }
 /**
  * @brief Calculate TAR checksum

--- a/uploadstblogs/src/archive_manager.c
+++ b/uploadstblogs/src/archive_manager.c
@@ -415,18 +415,20 @@ bool generate_archive_name(char* buffer, size_t buffer_size,
     }
 
     time_t now = time(NULL);
-    struct tm* tm_info = localtime(&now);
-    
-    if (!tm_info) {
-        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
-                "[%s:%d] Failed to get local time\n", __FUNCTION__, __LINE__);
+
+    struct tm tm_utc;
+    if (gmtime_r(&now, &tm_utc) == NULL) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] Failed to get UTC time\n", __FUNCTION__, __LINE__);
         return false;
     }
 
     char timestamp[32];
-    // Format: MM-DD-YY-HH-MMAM/PM (matches script: date "+%m-%d-%y-%I-%M%p")
-    strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p", tm_info);
-    
+    // Format UTC timestamp as MM-DD-YY-HH-MMAM/PM.
+    if (strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p", &tm_utc) == 0) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+                "[%s:%d] Failed to format timestamp\n", __FUNCTION__, __LINE__);
+        return false;
+    }
     // Remove colons from MAC address for filename (A8:4A:63 -> A84A63)
     char mac_clean[32];
     const char* src = mac_address;
@@ -448,7 +450,6 @@ bool generate_archive_name(char* buffer, size_t buffer_size,
     
     return true;
 }
-
 /**
  * @brief Calculate TAR checksum
  */

--- a/uploadstblogs/src/file_operations.c
+++ b/uploadstblogs/src/file_operations.c
@@ -348,12 +348,25 @@ int add_timestamp_to_files(const char* dir_path)
 
     // Get current timestamp in script format: MM-DD-YY-HH-MMAM/PM-
     time_t now = time(NULL);
-    struct tm* tm_info = localtime(&now);
+    struct tm tm_utc;
+    if (gmtime_r(&now, &tm_utc) == NULL) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] Failed to get UTC time\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
     char timestamp[32];
-    strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p-", tm_info);
-    
+    size_t timestamp_len = strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p-", &tm_utc);
+    if (timestamp_len == 0) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+                "[%s:%d] Failed to format UTC timestamp\n",
+                __FUNCTION__, __LINE__);
+        return -1;
+    }
+
     // Store timestamp prefix globally for removal later (matches script behavior)
+
     strncpy(g_timestamp_prefix, timestamp, sizeof(g_timestamp_prefix) - 1);
+
+    g_timestamp_prefix[sizeof(g_timestamp_prefix) - 1] = '\0';
 
     DIR* dir = opendir(dir_path);
     if (!dir) {
@@ -412,7 +425,6 @@ int add_timestamp_to_files(const char* dir_path)
 
     return (error_count > 0) ? -1 : 0;
 }
-
 /**
  * @brief Remove timestamp prefix from all files in directory
  * @param dir_path Directory containing files to rename
@@ -538,9 +550,13 @@ int add_timestamp_to_files_uploadlogsnow(const char* dir_path)
 
     // Get current timestamp in script format: MM-DD-YY-HH-MMAM/PM-
     time_t now = time(NULL);
-    struct tm* tm_info = localtime(&now);
+    struct tm tm_utc;
+    if (gmtime_r(&now, &tm_utc) == NULL) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] Failed to get UTC time\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
     char timestamp[32];
-    strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p-", tm_info);
+    strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p-", &tm_utc);
     
     // Store timestamp prefix globally for removal later (matches script behavior)
     strncpy(g_timestamp_prefix, timestamp, sizeof(g_timestamp_prefix) - 1);
@@ -641,7 +657,6 @@ int add_timestamp_to_files_uploadlogsnow(const char* dir_path)
 
     return (error_count > 0) ? -1 : 0;
 }
-
 /**
  * @brief Move all contents from source directory to destination directory
  * @param src_dir Source directory

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -406,11 +406,22 @@ static int ondemand_setup(RuntimeContext* ctx, SessionState* session)
     // Create timestamp for permanent log path (for logging purposes only)
     char timestamp[64];
     time_t now = time(NULL);
-    struct tm* tm_info = localtime(&now);
-    strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p-logbackup", tm_info);
+    struct tm tm_utc;
+    size_t timestamp_len;
+    if (gmtime_r(&now, &tm_utc) == NULL) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] Failed to get UTC time\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+    timestamp_len = strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p-logbackup", &tm_utc);
+    if (timestamp_len == 0U) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+                "[%s:%d] Failed to format timestamp for permanent log path\n",
+                __FUNCTION__, __LINE__);
+        return -1;
+    }
 
     char perm_log_path[MAX_PATH_LENGTH];
-    int written = snprintf(perm_log_path, sizeof(perm_log_path), "%s/%s", 
+    int written = snprintf(perm_log_path, sizeof(perm_log_path), "%s/%s",
                           ctx->log_path, timestamp);
     
     if (written >= (int)sizeof(perm_log_path)) {
@@ -456,7 +467,6 @@ static int ondemand_setup(RuntimeContext* ctx, SessionState* session)
 
     return 0;
 }
-
 /**
  * @brief Archive phase for ONDEMAND strategy
  * 


### PR DESCRIPTION
[Reason For change : Log-backup generated name change to local time to UTC