### PR TITLE
RDKEMW-17725 : [support/8.5] [RDKEMW][ALPACA IT] Device not Going to Deepsleep.

### DIFF
--- a/uploadstblogs/src/event_manager.c
+++ b/uploadstblogs/src/event_manager.c
@@ -184,10 +184,9 @@ void emit_upload_failure(const RuntimeContext* ctx, const SessionState* session)
 void emit_upload_aborted(void)
 {
     RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB, 
-            "[%s:%d] Upload operation was aborted\n", __FUNCTION__, __LINE__);
+            "[%s:%d] Not Uploading Logs with DCM \n", __FUNCTION__, __LINE__);
     
-    // Send abort events
-    send_iarm_event("LogUploadEvent", LOG_UPLOAD_ABORTED);
+    send_iarm_event("LogUploadEvent", LOG_UPLOAD_FAILED);
     send_iarm_event_maintenance(MAINT_LOGUPLOAD_ERROR);
 }
 

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -897,6 +897,7 @@ static int reboot_upload(RuntimeContext* ctx, SessionState* session)
         RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, 
                 "[%s:%d] Upload not allowed based on reboot reason and RFC settings\n", 
                 __FUNCTION__, __LINE__);
+	emit_upload_aborted();
         return 0;
     }
 

--- a/uploadstblogs/unittest/strategies_gtest.cpp
+++ b/uploadstblogs/unittest/strategies_gtest.cpp
@@ -166,6 +166,11 @@ void emit_no_logs_reboot(const RuntimeContext* ctx) {
     // No-op for tests
 }
 
+// Mock for emit_upload_aborted used by strategies.c
+void emit_upload_aborted(void) {
+    // No-op for tests
+}
+
 int remove_timestamp_from_files(const char* dirpath) {
     return 0; // Success
 }


### PR DESCRIPTION
Reason for change: Add iarm eventing on maintenance reboot no logupload case
Test Procedure: Verify build is passing
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)