### PR TITLE
RDKEMW-19238: Cleanup of stale archives and log backups to the uploadSTBLogs

### DIFF
--- a/uploadstblogs/src/cleanup_handler.c
+++ b/uploadstblogs/src/cleanup_handler.c
@@ -237,7 +237,7 @@ int cleanup_old_archives(const char *log_path)
         snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
 
         struct stat st;
-        if (stat(fullpath, &st) != 0) {
+        if (lstat(fullpath, &st) != 0) {
             continue;
         }
 

--- a/uploadstblogs/src/cleanup_handler.c
+++ b/uploadstblogs/src/cleanup_handler.c
@@ -226,13 +226,12 @@ int cleanup_old_archives(const char *log_path)
     }
     
     int dfd = dirfd(dir);
-    if (dfd < 0) {
-        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
-                "[%s:%d] dirfd() failed for: %s\n",
-                __FUNCTION__, __LINE__, log_path);
-        closedir(dir);
-        return -1;
-    }
+    if (dfd < 0) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] dirfd() failed for: %s\n", __FUNCTION__, __LINE__, log_path);
+        closedir(dir);
+        return -1;
+    }
+
     int removed_count = 0;
     struct dirent *entry;
     char fullpath[512];

--- a/uploadstblogs/src/cleanup_handler.c
+++ b/uploadstblogs/src/cleanup_handler.c
@@ -253,9 +253,7 @@ int cleanup_old_archives(const char *log_path)
                 continue;
             }
 
-            RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB,
-                    "[%s:%d] Removing old archive: %s\n",
-                    __FUNCTION__, __LINE__, fullpath);
+            RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, "[%s:%d] Removing old archive: %s\n", __FUNCTION__, __LINE__, fullpath);
 
             if (unlink(fullpath) == 0) {
                 removed_count++;

--- a/uploadstblogs/src/cleanup_handler.c
+++ b/uploadstblogs/src/cleanup_handler.c
@@ -229,7 +229,7 @@ int cleanup_old_archives(const char *log_path)
     int removed_count = 0;
     struct dirent *entry;
     char fullpath[512];
-
+    
     while ((entry = readdir(dir)) != NULL) {
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
             continue;
@@ -255,13 +255,20 @@ int cleanup_old_archives(const char *log_path)
                 continue;
             }
 
-            int path_written = snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
-            if (path_written < 0 || path_written >= (int)sizeof(fullpath)) {
-                RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB,
-                        "[%s:%d] Path too long, skipping file: %s/%s\n",
-                        __FUNCTION__, __LINE__, log_path, entry->d_name);
-                continue;
-            }
+            int path_written = snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
+
+            if (path_written < 0 || path_written >= (int)sizeof(fullpath)) {
+
+                RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB,
+
+                        "[%s:%d] Path too long, skipping file: %s/%s\n",
+
+                        __FUNCTION__, __LINE__, log_path, entry->d_name);
+
+                continue;
+
+            }
+
             RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, "[%s:%d] Removing old archive: %s\n", __FUNCTION__, __LINE__, fullpath);
             /* unlinkat operates on the same dir FD — no path race possible */
             if (unlinkat(dfd, entry->d_name, 0) == 0) {

--- a/uploadstblogs/src/cleanup_handler.c
+++ b/uploadstblogs/src/cleanup_handler.c
@@ -225,24 +225,26 @@ int cleanup_old_archives(const char *log_path)
         return -1;
     }
     
+    int dfd = dirfd(dir);
     int removed_count = 0;
     struct dirent *entry;
     char fullpath[512];
-    
+
     while ((entry = readdir(dir)) != NULL) {
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
             continue;
         }
         
-        snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
-
         struct stat st;
-        if (lstat(fullpath, &st) != 0) {
+        /* fstatat with AT_SYMLINK_NOFOLLOW on the open dir FD: check and subsequent
+         * unlinkat both refer to the same dir entry, eliminating the TOCTOU race. */
+        if (fstatat(dfd, entry->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0) {
             continue;
         }
 
         if (S_ISDIR(st.st_mode)) {
             /* Recurse into subdirectories (matches shell: find $LOG_PATH -name "*.tgz") */
+            snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
             int sub_count = cleanup_old_archives(fullpath);
             if (sub_count > 0) {
                 removed_count += sub_count;
@@ -253,9 +255,11 @@ int cleanup_old_archives(const char *log_path)
                 continue;
             }
 
+            snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
             RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, "[%s:%d] Removing old archive: %s\n", __FUNCTION__, __LINE__, fullpath);
 
-            if (unlink(fullpath) == 0) {
+            /* unlinkat operates on the same dir FD — no path race possible */
+            if (unlinkat(dfd, entry->d_name, 0) == 0) {
                 removed_count++;
             } else {
                 RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB,

--- a/uploadstblogs/src/cleanup_handler.c
+++ b/uploadstblogs/src/cleanup_handler.c
@@ -226,6 +226,13 @@ int cleanup_old_archives(const char *log_path)
     }
     
     int dfd = dirfd(dir);
+    if (dfd < 0) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB,
+                "[%s:%d] dirfd() failed for: %s\n",
+                __FUNCTION__, __LINE__, log_path);
+        closedir(dir);
+        return -1;
+    }
     int removed_count = 0;
     struct dirent *entry;
     char fullpath[512];

--- a/uploadstblogs/src/cleanup_handler.c
+++ b/uploadstblogs/src/cleanup_handler.c
@@ -255,9 +255,14 @@ int cleanup_old_archives(const char *log_path)
                 continue;
             }
 
-            snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
+            int path_written = snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
+            if (path_written < 0 || path_written >= (int)sizeof(fullpath)) {
+                RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB,
+                        "[%s:%d] Path too long, skipping file: %s/%s\n",
+                        __FUNCTION__, __LINE__, log_path, entry->d_name);
+                continue;
+            }
             RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, "[%s:%d] Removing old archive: %s\n", __FUNCTION__, __LINE__, fullpath);
-
             /* unlinkat operates on the same dir FD — no path race possible */
             if (unlinkat(dfd, entry->d_name, 0) == 0) {
                 removed_count++;

--- a/uploadstblogs/src/cleanup_handler.c
+++ b/uploadstblogs/src/cleanup_handler.c
@@ -37,6 +37,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <regex.h>
+#include <ctype.h>
 #include "cleanup_handler.h"
 #include "context_manager.h"
 #include "event_manager.h"
@@ -229,31 +230,46 @@ int cleanup_old_archives(const char *log_path)
     char fullpath[512];
     
     while ((entry = readdir(dir)) != NULL) {
-        // Check if file ends with .tgz
-        size_t len = strlen(entry->d_name);
-        if (len < 5 || strcmp(entry->d_name + len - 4, ".tgz") != 0) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
             continue;
         }
         
         snprintf(fullpath, sizeof(fullpath), "%s/%s", log_path, entry->d_name);
-        
-        RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB,
-                "[%s:%d] Removing old archive: %s\n",
-                __FUNCTION__, __LINE__, fullpath);
-        
-        // Use unlink to remove file (more explicit than remove)
-        if (unlink(fullpath) == 0) {
-            removed_count++;
-        } else {
-            RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB,
-                    "[%s:%d] Failed to remove: %s\n", 
+
+        struct stat st;
+        if (stat(fullpath, &st) != 0) {
+            continue;
+        }
+
+        if (S_ISDIR(st.st_mode)) {
+            /* Recurse into subdirectories (matches shell: find $LOG_PATH -name "*.tgz") */
+            int sub_count = cleanup_old_archives(fullpath);
+            if (sub_count > 0) {
+                removed_count += sub_count;
+            }
+        } else if (S_ISREG(st.st_mode)) {
+            size_t len = strlen(entry->d_name);
+            if (len < 5 || strcmp(entry->d_name + len - 4, ".tgz") != 0) {
+                continue;
+            }
+
+            RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB,
+                    "[%s:%d] Removing old archive: %s\n",
                     __FUNCTION__, __LINE__, fullpath);
+
+            if (unlink(fullpath) == 0) {
+                removed_count++;
+            } else {
+                RDK_LOG(RDK_LOG_WARN, LOG_UPLOADSTB,
+                        "[%s:%d] Failed to remove: %s\n",
+                        __FUNCTION__, __LINE__, fullpath);
+            }
         }
     }
     
     closedir(dir);
     
-    RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB,
+    RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB,
             "[%s:%d] Archive cleanup complete: removed %d .tgz files from %s\n",
             __FUNCTION__, __LINE__, removed_count, log_path);
     

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -896,7 +896,7 @@ static int reboot_upload(RuntimeContext* ctx, SessionState* session)
         RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, 
                 "[%s:%d] Upload not allowed based on reboot reason and RFC settings\n", 
                 __FUNCTION__, __LINE__);
-		strncpy(session->archive_file, archive_path, sizeof(session->archive_file) - 1)
+		strncpy(session->archive_file, archive_path, sizeof(session->archive_file) - 1);
         emit_upload_aborted();
         return 0;
     }

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -47,6 +47,7 @@
 #include "rbus_interface.h"
 #include "rdk_debug.h"
 #include "event_manager.h"
+#include "cleanup_handler.h"
 
 #define ONDEMAND_TEMP_DIR "/tmp/log_on_demand"
 
@@ -686,25 +687,15 @@ static int reboot_setup(RuntimeContext* ctx, SessionState* session)
                 __FUNCTION__, __LINE__);
     }
 
-    // Delete old backup files (3+ days old)
-    // Remove old timestamp directories and logbackup directories
-    RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, 
-            "[%s:%d] Cleaning old backups (3+ days)\n", __FUNCTION__, __LINE__);
-    
-    int removed = remove_old_directories(ctx->log_path, "*-*-*-*-*M-", 3);
-    if (removed > 0) {
-        RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, 
-                "[%s:%d] Removed %d old timestamp directories\n", 
-                __FUNCTION__, __LINE__, removed);
+    // Clean up old log backup directories (older than 3 days)
+    RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, "[%s:%d] Cleaning old log backup directories (3+ days)\n", __FUNCTION__, __LINE__);
+    int removed_dirs = cleanup_old_log_backups(ctx->log_path, 3);
+    if (removed_dirs > 0) {
+        RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, "[%s:%d] Removed %d old log backup directories\n", __FUNCTION__, __LINE__, removed_dirs);
+    } else {
+        RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, "[%s:%d] No old log backup directories removed\n", __FUNCTION__, __LINE__);
     }
     
-    removed = remove_old_directories(ctx->log_path, "*-*-*-*-*M-logbackup", 3);
-    if (removed > 0) {
-        RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, 
-                "[%s:%d] Removed %d old logbackup directories\n", 
-                __FUNCTION__, __LINE__, removed);
-    }
-
     // Create timestamp for permanent log path
     char timestamp[64];
     time_t now = time(NULL);
@@ -1011,21 +1002,11 @@ static int reboot_cleanup(RuntimeContext* ctx, SessionState* session, bool uploa
     sleep(5);
 
     // Delete tar file
-    char tar_path[MAX_PATH_LENGTH];
-    int written = snprintf(tar_path, sizeof(tar_path), "%s/%s", 
-                          ctx->prev_log_path, session->archive_file);
-    
-    if (written >= (int)sizeof(tar_path)) {
-        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, 
-                "[%s:%d] Tar path too long\n", __FUNCTION__, __LINE__);
-        return -1;
-    }
-
-    if (file_exists(tar_path)) {
+    if (file_exists(session->archive_file)) {
         RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB, 
                 "[%s:%d] Removing tar file: %s\n", 
-                __FUNCTION__, __LINE__, tar_path);
-        remove_file(tar_path);
+                __FUNCTION__, __LINE__, session->archive_file);
+        remove_file(session->archive_file);
     }
 
     // Remove timestamps from filenames (restore original names)
@@ -1121,4 +1102,3 @@ static int reboot_cleanup(RuntimeContext* ctx, SessionState* session, bool uploa
 
     return 0;
 }
-

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -897,6 +897,7 @@ static int reboot_upload(RuntimeContext* ctx, SessionState* session)
                 "[%s:%d] Upload not allowed based on reboot reason and RFC settings\n", 
                 __FUNCTION__, __LINE__);
 		strncpy(session->archive_file, archive_path, sizeof(session->archive_file) - 1);
+		session->archive_file[sizeof(session->archive_file) - 1] = '\0';
         emit_upload_aborted();
         return 0;
     }

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -881,24 +881,24 @@ static int reboot_upload(RuntimeContext* ctx, SessionState* session)
             should_upload = true;
         }
     }
-    
-    if (!should_upload) {
-        RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, 
-                "[%s:%d] Upload not allowed based on reboot reason and RFC settings\n", 
-                __FUNCTION__, __LINE__);
-        emit_upload_aborted();
-        return 0;
-    }
 
-    // Construct full archive path using session archive filename
+	// Construct full archive path using session archive filename
     char archive_path[MAX_PATH_LENGTH];
-    int written = snprintf(archive_path, sizeof(archive_path), "%s/%s", 
-                          ctx->prev_log_path, session->archive_file);
+    int written = snprintf(archive_path, sizeof(archive_path), "%s/%s", ctx->prev_log_path, session->archive_file);
     
     if (written >= (int)sizeof(archive_path)) {
         RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, 
                 "[%s:%d] Archive path too long\n", __FUNCTION__, __LINE__);
         return -1;
+    }
+    
+    if (!should_upload) {
+        RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, 
+                "[%s:%d] Upload not allowed based on reboot reason and RFC settings\n", 
+                __FUNCTION__, __LINE__);
+		strncpy(session->archive_file, archive_path, sizeof(session->archive_file) - 1)
+        emit_upload_aborted();
+        return 0;
     }
 
     RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, 

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -1057,7 +1057,7 @@ static int reboot_cleanup(RuntimeContext* ctx, SessionState* session, bool uploa
     // Script lines 900-902: rm -rf + mkdir -p PREV_LOG_BACKUP_PATH
     // PREV_LOG_BACKUP_PATH = $LOG_PATH/PreviousLogs_backup/
     char prev_log_backup_path[MAX_PATH_LENGTH];
-    written = snprintf(prev_log_backup_path, sizeof(prev_log_backup_path), "%s/PreviousLogs_backup", 
+    int written = snprintf(prev_log_backup_path, sizeof(prev_log_backup_path), "%s/PreviousLogs_backup", 
                       ctx->log_path);
     
     if (written >= (int)sizeof(prev_log_backup_path)) {

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -699,8 +699,17 @@ static int reboot_setup(RuntimeContext* ctx, SessionState* session)
     // Create timestamp for permanent log path
     char timestamp[64];
     time_t now = time(NULL);
-    struct tm* tm_info = localtime(&now);
-    strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p-logbackup", tm_info);
+    struct tm tm_utc;
+    size_t timestamp_len;
+    if (gmtime_r(&now, &tm_utc) == NULL) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] Failed to get UTC time\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+    timestamp_len = strftime(timestamp, sizeof(timestamp), "%m-%d-%y-%I-%M%p-logbackup", &tm_utc);
+    if (timestamp_len == 0U) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_UPLOADSTB, "[%s:%d] Failed to format timestamp for permanent log path\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
 
     char perm_log_path[MAX_PATH_LENGTH];
     int written = snprintf(perm_log_path, sizeof(perm_log_path), "%s/%s", 

--- a/uploadstblogs/src/strategy_handler.c
+++ b/uploadstblogs/src/strategy_handler.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include "strategy_handler.h"
+#include "cleanup_handler.h"
 #include "rdk_debug.h"
 #include <string.h>
 
@@ -70,6 +71,8 @@ int execute_strategy_workflow(RuntimeContext* ctx, SessionState* session)
         return -1;
     }
 
+    // Remove stale .tgz archives from log path before any strategy runs.
+    cleanup_old_archives(ctx->log_path);
     // Verify context has valid data
     RDK_LOG(RDK_LOG_DEBUG, LOG_UPLOADSTB,
             "[%s:%d] Context check: ctx=%p, MAC='%s', device_type='%s'\n",
@@ -157,4 +160,3 @@ cleanup:
 
     return ret;
 }
-

--- a/uploadstblogs/unittest/cleanup_handler_gtest.cpp
+++ b/uploadstblogs/unittest/cleanup_handler_gtest.cpp
@@ -68,7 +68,10 @@ void regfree(regex_t *preg) {
 DIR* opendir(const char *dirname);
 struct dirent* readdir(DIR *dirp);
 int closedir(DIR *dirp);
+int dirfd(DIR *dirp);
 int stat(const char *pathname, struct stat *statbuf);
+int fstatat(int dfd, const char *pathname, struct stat *statbuf, int flags);
+int unlinkat(int dfd, const char *pathname, int flags);
 int remove(const char *pathname);
 int rmdir(const char *pathname);
 
@@ -123,6 +126,40 @@ struct dirent* readdir(DIR *dirp) {
 int closedir(DIR *dirp) {
     // Reset readdir count when closing directory
     mock_readdir_count = 0;
+    return 0;
+}
+
+int dirfd(DIR *dirp) {
+    // Return a dummy fd for the fake DIR pointer
+    return 5;
+}
+
+int fstatat(int dfd, const char *pathname, struct stat *statbuf, int flags) {
+    if (stat_fail || !pathname || !statbuf) {
+        return -1;
+    }
+    memset(statbuf, 0, sizeof(struct stat));
+
+    time_t now = time(NULL);
+    if (strstr(pathname, "11-30-25-03-45PM") || strstr(pathname, "old_archive")) {
+        statbuf->st_mtime = now - (5 * 24 * 60 * 60); // 5 days ago
+    } else {
+        statbuf->st_mtime = now - (1 * 24 * 60 * 60); // 1 day ago
+    }
+
+    if (strstr(pathname, "logbackup") || strstr(pathname, "normal_folder")) {
+        statbuf->st_mode = S_IFDIR | 0755;
+    } else {
+        statbuf->st_mode = S_IFREG | 0644;
+    }
+
+    return 0;
+}
+
+int unlinkat(int dfd, const char *pathname, int flags) {
+    if (remove_fail || !pathname) {
+        return -1;
+    }
     return 0;
 }
 

--- a/uploadstblogs/unittest/strategies_gtest.cpp
+++ b/uploadstblogs/unittest/strategies_gtest.cpp
@@ -60,6 +60,7 @@ bool rbus_get_bool_param(const char* param_name, bool* value);
 bool generate_archive_name(char* buffer, size_t buffer_size, const char* type, const char* timestamp);
 int create_dri_archive(RuntimeContext* ctx, const char* archive_path);
 void t2_count_notify(char* marker);
+int cleanup_old_log_backups(const char* log_path, int max_age_days);
 
 // Mock sleep function to avoid delays in tests
 unsigned int sleep(unsigned int seconds);
@@ -202,6 +203,10 @@ int create_dri_archive(RuntimeContext* ctx, const char* archive_path) {
 
 void t2_count_notify(char* marker) {
     // No-op for tests
+}
+
+int cleanup_old_log_backups(const char* log_path, int max_age_days) {
+    return 0; // Success
 }
 
 // Include the actual implementation for testing

--- a/uploadstblogs/unittest/strategy_handler_gtest.cpp
+++ b/uploadstblogs/unittest/strategy_handler_gtest.cpp
@@ -28,6 +28,7 @@
 extern "C" {
 #include "uploadstblogs_types.h"
 #include "strategy_handler.h"
+int cleanup_old_archives(const char* log_path);
 }
 
 // Mock strategy handlers for testing
@@ -96,6 +97,11 @@ static const StrategyHandler mock_dcm_handler = {
     .upload_phase = mock_upload_phase,
     .cleanup_phase = mock_cleanup_phase
 };
+
+// Mock implementation for cleanup_old_archives
+extern "C" int cleanup_old_archives(const char* log_path) {
+    return 0; // Success
+}
 
 // Override the external strategy handlers
 const StrategyHandler ondemand_strategy_handler = mock_ondemand_handler;


### PR DESCRIPTION
Adds centralized cleanup of stale archives and log backups to the uploadSTBLogs strategy workflow, moving reboot backup cleanup through cleanup_handler.

Changes:

Runs stale .tgz archive cleanup before strategy execution.
Replaces reboot backup cleanup with cleanup_old_log_backups().
Updates archive cleanup to recurse into subdirectories.