### PR TITLE
RDKEMW-22204 : Logupload is not triggering after maintenance reboot

### DIFF
--- a/backup_logs/src/backup_engine.c
+++ b/backup_logs/src/backup_engine.c
@@ -335,7 +335,7 @@ int backup_execute_hdd_disabled_strategy(const backup_config_t* config) {
             strcat(file_path, "/");
             strcat(file_path, entry->d_name);
             if (remove(file_path) != 0) {
-                RDK_LOG(RDK_LOG_DEBUG,, LOG_BACKUP_LOGS, "Failed to remove file during log cleanup: %s\n", file_path);
+                RDK_LOG(RDK_LOG_DEBUG, LOG_BACKUP_LOGS, "Failed to remove file during log cleanup: %s\n", file_path);
             }
         }
         closedir(dir);

--- a/backup_logs/src/backup_engine.c
+++ b/backup_logs/src/backup_engine.c
@@ -335,7 +335,7 @@ int backup_execute_hdd_disabled_strategy(const backup_config_t* config) {
             strcat(file_path, "/");
             strcat(file_path, entry->d_name);
             if (remove(file_path) != 0) {
-                RDK_LOG(RDK_LOG_WARN, LOG_BACKUP_LOGS, "Failed to remove file during log cleanup: %s\n", file_path);
+                RDK_LOG(RDK_LOG_DEBUG,, LOG_BACKUP_LOGS, "Failed to remove file during log cleanup: %s\n", file_path);
             }
         }
         closedir(dir);

--- a/dcm.c
+++ b/dcm.c
@@ -37,6 +37,7 @@
 #include "dcm_rbus.h"
 #include "dcm_cronparse.h"
 #include "dcm_schedjob.h"
+#include "uploadstblogs.h"
 
 static DCMDHandle *g_pdcmHandle = NULL;
 
@@ -68,7 +69,42 @@ static VOID dcmRunJobs(const INT8* profileName, VOID *pHandle)
         pRDKPath = DCM_LIB_PATH;
     }
 
-    if(strcmp(profileName, DCM_DIFD_SCHED) == 0) {
+    if(strcmp(profileName, DCM_LOGUPLOAD_SCHED) == 0) {
+        INT8 *pPrctl = dcmSettingsGetUploadProtocol(pdcmHandle->pDcmSetHandle);
+        INT8 *pURL   = dcmSettingsGetUploadURL(pdcmHandle->pDcmSetHandle);
+
+        if(pPrctl == NULL) {
+            DCMWarn("Log Upload protocol is NULL, using HTTP\n");
+            pPrctl = "HTTP";
+        }
+        if(pURL == NULL) {
+            DCMWarn("Log Upload URL is NULL, using %s\n", DCM_DEF_LOG_URL);
+            pURL = DCM_DEF_LOG_URL;
+        }
+
+        DCMInfo("\nStart log upload via library API\n");
+
+        // Call uploadstblogs library API instead of shell script
+        UploadSTBLogsParams params = {
+            .flag = 0,
+            .dcm_flag = 1,
+            .upload_on_reboot = false,
+            .upload_protocol = pPrctl,
+            .upload_http_link = pURL,
+            .trigger_type = TRIGGER_SCHEDULED,
+            .rrd_flag = false,
+            .rrd_file = NULL
+        };
+#ifndef GTEST_ENABLE
+        int result = uploadstblogs_run(&params);
+        if (result != 0) {
+            DCMError("Log upload failed with error code: %d\n", result);
+        } else {
+            DCMInfo("Log upload completed successfully\n");
+        }
+#endif
+    }
+    else if(strcmp(profileName, DCM_DIFD_SCHED) == 0) {
         DCMInfo("Start FW update Script\n");
         snprintf(pExecBuff, EXECMD_BUFF_SIZE, "/bin/sh %s/swupdate_utility.sh 0 2 >> /opt/logs/swupdate.log 2>&1",
                                                pRDKPath);
@@ -166,6 +202,15 @@ INT32 dcmDaemonMainInit(DCMDHandle *pdcmHandle)
         return ret;
     }
 
+    /* Add log upload job to Schecduler */
+    pdcmHandle->pLogSchedHandle  = dcmSchedAddJob(DCM_LOGUPLOAD_SCHED,
+                                                  (DCMSchedCB)dcmRunJobs,
+                                                  (VOID *) pdcmHandle);
+    if(pdcmHandle->pLogSchedHandle == NULL) {
+        DCMError("Failed to Add Log Scheduler jobs\n");
+        return DCM_FAILURE;
+    }
+
     /* Add FW update job to Schecduler */
     pdcmHandle->pDifdSchedHandle = dcmSchedAddJob(DCM_DIFD_SCHED,
                                                   (DCMSchedCB)dcmRunJobs,
@@ -196,7 +241,9 @@ VOID dcmDaemonMainUnInit(DCMDHandle *pdcmHandle)
 
     dcmSettingsUnInit(pdcmHandle->pDcmSetHandle);
     dcmRbusUnInit(pdcmHandle->pRbusHandle);
+    dcmSchedStopJob(pdcmHandle->pLogSchedHandle);
     dcmSchedStopJob(pdcmHandle->pDifdSchedHandle);
+    dcmSchedRemoveJob(pdcmHandle->pLogSchedHandle);
     dcmSchedRemoveJob(pdcmHandle->pDifdSchedHandle);
     dcmSchedUnInit();
 
@@ -321,11 +368,11 @@ int main(int argc, char* argv[])
                 continue;
             }
 
-            INT8 unusedLogCron[16] = {0};
             ret = dcmSettingParseConf(g_pdcmHandle->pDcmSetHandle, pconfPath,
-                                      unusedLogCron,
+                                      g_pdcmHandle->logCron,
                                       g_pdcmHandle->difdCron);
             if(ret == DCM_SUCCESS) {
+                dcmSchedStartJob(g_pdcmHandle->pLogSchedHandle, g_pdcmHandle->logCron);
                 dcmSchedStartJob(g_pdcmHandle->pDifdSchedHandle, g_pdcmHandle->difdCron);
 
                 ret = dcmIARMEvntSend(DCM_IARM_COMPLETE);

--- a/dcm.h
+++ b/dcm.h
@@ -26,6 +26,7 @@ extern "C"
 {
 #endif
 
+#define DCM_LOGUPLOAD_SCHED    "DCM_LOG_UPLOAD"
 #define DCM_DIFD_SCHED         "DCM_FW_UPDATE"
 
 typedef struct _dcmdHandle
@@ -34,8 +35,10 @@ typedef struct _dcmdHandle
     BOOL  isDCMRunning;
     VOID *pRbusHandle;
     VOID *pDcmSetHandle;
+    VOID *pLogSchedHandle;
     VOID *pDifdSchedHandle;
     INT8 *pExecBuff;
+    INT8  logCron[16];
     INT8  difdCron[16];
 
 } DCMDHandle;

--- a/dcm_parseconf.c
+++ b/dcm_parseconf.c
@@ -37,6 +37,7 @@
 #include "dcm_utils.h"
 #include "dcm_rbus.h"
 #include "dcm_parseconf.h"
+#include "uploadstblogs.h"
 
 static INT32 g_bMMEnable = 0;
 
@@ -577,6 +578,72 @@ INT32 dcmSettingParseConf(VOID *pHandle, INT8 *pConffile,
 
     DCMInfo("DCM_DIFD_CRON: %s\n", pDifdCron);
 
+    if(uploadCheck == 1 && pdcmSetHandle->bRebootFlag == 0) {
+        DCMInfo("Triggering log upload with reboot flag via library API\n");
+        UploadSTBLogsParams params = {
+            .flag = 1,
+            .dcm_flag = 1,
+            .upload_on_reboot = true,
+            .upload_protocol = pUploadprtl,
+            .upload_http_link = pUploadURL,
+            .trigger_type = TRIGGER_REBOOT,
+            .rrd_flag = false,
+            .rrd_file = NULL
+        };
+#ifndef GTEST_ENABLE
+        int result = uploadstblogs_run(&params);
+        if (result != 0) {
+            DCMError("Log upload (reboot=true) failed: %d\n", result);
+        }
+#endif
+    }
+    else if (uploadCheck == 0 && pdcmSetHandle->bRebootFlag == 0) {
+        DCMInfo("Triggering log upload without reboot flag via library API\n");
+        UploadSTBLogsParams params = {
+            .flag = 1,
+            .dcm_flag = 1,
+            .upload_on_reboot = false,
+            .upload_protocol = pUploadprtl,
+            .upload_http_link = pUploadURL,
+            .trigger_type = TRIGGER_SCHEDULED,
+            .rrd_flag = false,
+            .rrd_file = NULL
+        };
+#ifndef GTEST_ENABLE
+        int result = uploadstblogs_run(&params);
+        if (result != 0) {
+            DCMError("Log upload (reboot=false) failed: %d\n", result);
+        }
+#endif
+    }
+    else {
+        DCMWarn ("Nothing to do here for uploadCheck value = %d\n", uploadCheck);
+    }
+
+    if(strlen(pLogCron) == 0) {
+        DCMWarn ("Uploading logs as DCM response is either null or not present\n");
+        
+        UploadSTBLogsParams params = {
+            .flag = 1,
+            .dcm_flag = 1,
+            .upload_on_reboot = false,
+            .upload_protocol = pUploadprtl,
+            .upload_http_link = pUploadURL,
+            .trigger_type = TRIGGER_SCHEDULED,
+            .rrd_flag = false,
+            .rrd_file = NULL
+        };
+#ifndef GTEST_ENABLE
+        int result = uploadstblogs_run(&params);
+        if (result != 0) {
+            DCMError("Log upload (empty cron) failed: %d\n", result);
+        }
+#endif
+    }
+    else {
+        DCMInfo ("%s is present setting cron jobs\n", DCM_LOGUPLOAD_CRON);
+    }
+
     if(strlen(pDifdCron) == 0) {
         DCMWarn ("difdCron is empty\n");
     }
@@ -764,7 +831,6 @@ INT32 (*getdcmSettingJsonGetVal(void))(VOID*, INT8*, INT8*, INT32*, INT32*)
     return &dcmSettingJsonGetVal;
 }
 #endif
-
 
 
 

--- a/uploadstblogs/src/strategies.c
+++ b/uploadstblogs/src/strategies.c
@@ -896,7 +896,7 @@ static int reboot_setup(RuntimeContext* ctx, SessionState* session)
             return -1;
         }
 		else {
-            RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, "[%s:%d] NTP sync sentinel detected. Proceeding.\n", __FUNCTION__, __LINE__);
+            RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, "[%s:%d]  backup_logs sentinel detected. Proceeding.\n", __FUNCTION__, __LINE__);
         }
     }
 

--- a/uploadstblogs/src/uploadstblogs.c
+++ b/uploadstblogs/src/uploadstblogs.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 #include <time.h>
 #include <dirent.h>
+#include "common_device_api.h"
 
 #include "uploadstblogs.h"
 #include "uploadstblogs_types.h"
@@ -474,7 +475,13 @@ int uploadstblogs_execute(int argc, char** argv)
 
     /* Cleanup IARM connection */
     cleanup_iarm_connection();
-
+        // Log total time from boot to upload completion
+    double uptime_seconds = 0.0;
+    if (get_system_uptime(&uptime_seconds)) {
+        RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, 
+                "[%s:%d] log upload completed at system uptime %.0f seconds\n", 
+                __FUNCTION__, __LINE__, uptime_seconds);
+    }
     /* Release lock and exit */
     release_lock();
     return ret;

--- a/uploadstblogs/src/uploadstblogs.c
+++ b/uploadstblogs/src/uploadstblogs.c
@@ -478,9 +478,7 @@ int uploadstblogs_execute(int argc, char** argv)
         // Log total time from boot to upload completion
     double uptime_seconds = 0.0;
     if (get_system_uptime(&uptime_seconds)) {
-        RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, 
-                "[%s:%d] log upload completed at system uptime %.0f seconds\n", 
-                __FUNCTION__, __LINE__, uptime_seconds);
+        RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, "[%s:%d] log upload completed at system uptime %.0f seconds\n", __FUNCTION__, __LINE__, uptime_seconds);
     }
     /* Release lock and exit */
     release_lock();

--- a/uploadstblogs/src/uploadstblogs.c
+++ b/uploadstblogs/src/uploadstblogs.c
@@ -475,7 +475,7 @@ int uploadstblogs_execute(int argc, char** argv)
 
     /* Cleanup IARM connection */
     cleanup_iarm_connection();
-        // Log total time from boot to upload completion
+    // Log total time from boot to upload completion
     double uptime_seconds = 0.0;
     if (get_system_uptime(&uptime_seconds)) {
         RDK_LOG(RDK_LOG_INFO, LOG_UPLOADSTB, "[%s:%d] log upload completed at system uptime %.0f seconds\n", __FUNCTION__, __LINE__, uptime_seconds);


### PR DESCRIPTION
Reason for change : Keeping dcm logupload trigger as it is, to handle logupload during maintenance reboot